### PR TITLE
regexp for words splitting updated

### DIFF
--- a/lib/Text/WordDiff.pm
+++ b/lib/Text/WordDiff.pm
@@ -11,7 +11,7 @@ $VERSION = '0.08';
 # _Mastering Regular Expressions_, p. 132.
 my $BEGIN_WORD = $] >= 5.006
     ? qr/(?:(?<!\p{IsWord})(?=\p{IsWord})|(?<!\p{IsPunct})(?=\p{IsPunct})|(?<!\p{IsCntrl})(?=\p{IsCntrl}))/msx
-    : qr/(?<!\w)(?=\w)/msx;
+    : qr/(?<!\w)(?=\w)|(?<![\]\[!"#$%&'()*+,\.\/:;<=>?@\^_`{|}~-])(?=[\]\[!"#$%&'()*+,\.\/:;<=>?@\^_`{|}~-])|(?<![\n\r\t])(?=[\n\r\v])/msx;;
 
 my %styles = (
     ANSIColor    => undef,

--- a/t/ansicolor.t
+++ b/t/ansicolor.t
@@ -45,15 +45,19 @@ my $time1     = localtime( (stat $filename1)[9] );
 my $time2     = localtime( (stat $filename2)[9] );
 my $header    = "--- $filename1\t$time1\n+++ $filename2\t$time2\n";
 
-my $file_diff = 'This is a ' . BOLD . RED . STRIKETHROUGH . "tst;\n"
-              . 'it ' . RESET . BOLD . GREEN . UNDERLINE . "test.\n"
-              . 'It ' . RESET . "is only a\n"
+my $file_diff = 'This is a ' . BOLD . RED . STRIKETHROUGH . "tst;"
+              . RESET . BOLD . GREEN . UNDERLINE . "test." . RESET . "\n"
+              . BOLD . RED . STRIKETHROUGH . "it " . RESET 
+              . BOLD . GREEN . UNDERLINE . "It " . RESET . "is only a\n"
               . 'test. Had ' . BOLD . RED . STRIKETHROUGH . 'it ' . RESET
               . BOLD . GREEN . UNDERLINE . 'this ' . RESET . "been an\n"
               . "actual diff, the results would\n"
-              . 'have been output to ' . BOLD . RED . STRIKETHROUGH
-              . "HTML.\n" . RESET . BOLD . GREEN . UNDERLINE
-              . "the terminal.\n" . RESET;
+              . 'have been output to ' . BOLD . RED . STRIKETHROUGH . "HTML"
+              . RESET . BOLD . GREEN . UNDERLINE . "the terminal" . RESET . ".\n\n"
+              . 'Some string with funny ' . BOLD . RED . STRIKETHROUGH . '$'
+              . RESET . BOLD . GREEN . UNDERLINE . '@' . RESET . "\n"
+              . 'chars in the end' . BOLD . RED . STRIKETHROUGH . '*'
+              . RESET . BOLD . GREEN . UNDERLINE . '?' . RESET . "\n";
 
 is word_diff($filename1, $filename2), $header . $file_diff,
     'Diff by file name should include a header';

--- a/t/data/left.txt
+++ b/t/data/left.txt
@@ -3,3 +3,6 @@ it is only a
 test. Had it been an
 actual diff, the results would
 have been output to HTML.
+
+Some string with funny $
+chars in the end*

--- a/t/data/right.txt
+++ b/t/data/right.txt
@@ -3,3 +3,6 @@ It is only a
 test. Had this been an
 actual diff, the results would
 have been output to the terminal.
+
+Some string with funny @
+chars in the end?

--- a/t/html.t
+++ b/t/html.t
@@ -45,15 +45,21 @@ my $time2     = localtime( (stat $filename2)[9] );
 my $header    = qq{<span class="fileheader">--- $filename1\t$time1\n}
               . qq{+++ $filename2\t$time2\n</span>};
 
-my $file_diff = qq{<div class="file">$header<span class="hunk">This is a }
-              . qq{</span><span class="hunk"><del>tst;\nit </del><ins>test.\n}
-              . qq{It </ins></span><span class="hunk">is only a\n}
-              . qq{test. Had </span><span class="hunk"><del>it </del>}
-              . qq{<ins>this </ins></span><span class="hunk">been an\n}
+my $file_diff = qq{<div class="file">$header<span class="hunk">This is a </span>}
+              . qq{<span class="hunk"><del>tst;</del><ins>test.</ins></span>}
+              . qq{<span class="hunk">\n</span>}
+              . qq{<span class="hunk"><del>it </del><ins>It </ins></span>}
+              . qq{<span class="hunk">is only a\ntest. Had </span>}
+              . qq{<span class="hunk"><del>it </del><ins>this </ins></span>}
+              . qq{<span class="hunk">been an\n}
               . qq{actual diff, the results would\n}
-              . qq{have been output to </span><span class="hunk"><del>HTML.\n}
-              . qq{</del><ins>the terminal.\n</ins></span></div>}
-              ;
+              . qq{have been output to </span><span class="hunk"><del>HTML</del>}
+              . qq{<ins>the terminal</ins></span>}
+              . qq{<span class="hunk">.\n\nSome string with funny </span>}
+              . qq{<span class="hunk"><del>\$</del><ins>\@</ins></span>}
+              . qq{<span class="hunk">\nchars in the end</span>}
+              . qq{<span class="hunk"><del>*</del><ins>?</ins></span>}
+              . qq{<span class="hunk">\n</span></div>};
 
 is word_diff($filename1, $filename2, \%opts), $file_diff,
     'Diff by file name should include a header';

--- a/t/htmltwolines.t
+++ b/t/htmltwolines.t
@@ -50,18 +50,27 @@ my $header1    = qq{<span class="fileheader">--- $filename1 $time1</span>};
 my $header2    = qq{<span class="fileheader">+++ $filename2 $time2</span>};
 
 my $file_diff = qq{<div class="file">$header1}
-	. qq{<span class="hunk">This is a </span><span class="hunk"><del>tst;\n}
-	. qq{it </del></span><span class="hunk">is only a\n}
+	. qq{<span class="hunk">This is a </span><span class="hunk"><del>tst;</del></span>}
+	. qq{<span class="hunk">\n</span>}
+	. qq{<span class="hunk"><del>it </del></span><span class="hunk">is only a\n}
 	. qq{test. Had </span><span class="hunk"><del>it </del></span><span class="hunk">been an\n}
 	. qq{actual diff, the results would\n}
-	. qq{have been output to </span><span class="hunk"><del>HTML.\n</del></span></div>\n}
+	. qq{have been output to </span><span class="hunk"><del>HTML</del></span>}
+	. qq{<span class="hunk">.\n\nSome string with funny </span>}
+	. qq{<span class="hunk"><del>\$</del></span>}
+	. qq{<span class="hunk">\nchars in the end</span>}
+	. qq{<span class="hunk"><del>*</del></span><span class="hunk">\n</span></div>\n}
 	. qq{<div class="file">$header2}
-	. qq{<span class="hunk">This is a </span><span class="hunk"><ins>test.\n}
-	. qq{It </ins></span><span class="hunk">is only a\n}
+	. qq{<span class="hunk">This is a </span><span class="hunk"><ins>test.</ins></span>}
+	. qq{<span class="hunk">\n</span>}
+	. qq{<span class="hunk"><ins>It </ins></span><span class="hunk">is only a\n}
 	. qq{test. Had </span><span class="hunk"><ins>this </ins></span><span class="hunk">been an\n}
 	. qq{actual diff, the results would\n}
-	. qq{have been output to </span><span class="hunk"><ins>the terminal.\n</ins></span></div>\n}
-    ;
+	. qq{have been output to </span><span class="hunk"><ins>the terminal</ins></span>}
+	. qq{<span class="hunk">.\n\nSome string with funny </span>}
+	. qq{<span class="hunk"><ins>\@</ins></span>}
+	. qq{<span class="hunk">\nchars in the end</span>}
+	. qq{<span class="hunk"><ins>?</ins></span><span class="hunk">\n</span></div>\n};
 
 is word_diff($filename1, $filename2, \%opts), $file_diff,
     'Diff by file name should include a header';


### PR DESCRIPTION
Hi!

I was happy to find out your module for word diffs. It does exactly what I need, almost exactly. The only problem - when we add a new line or punctuation symbols after some word, the default regexp treat them as part of the word, and show like whole word was changed. Like this:

http://dl.dropbox.com/u/13010428/word_diff_default.png

I've updated regexp accordingly, and now all command and punctuation symbols are been splitting to their owns chunks. I suppose this looks a little better:

http://dl.dropbox.com/u/13010428/word_diff_updated.png

Thanks again for this module, you've saved me a lot of time, I hope I could help to make int better.
Bye.
