### PR TITLE
I've updated regexp and tests.

### DIFF
--- a/lib/Text/WordDiff.pm
+++ b/lib/Text/WordDiff.pm
@@ -11,7 +11,7 @@ $VERSION = '0.08';
 # _Mastering Regular Expressions_, p. 132.
 my $BEGIN_WORD = $] >= 5.006
     ? qr/(?:(?<!\p{IsWord})(?=\p{IsWord})|(?<!\p{IsPunct})(?=\p{IsPunct})|(?<!\p{IsCntrl})(?=\p{IsCntrl}))/msx
-    : qr/(?<!\w)(?=\w)|(?<![\]\[!"#$%&'()*+,\.\/:;<=>?@\^_`{|}~-])(?=[\]\[!"#$%&'()*+,\.\/:;<=>?@\^_`{|}~-])|(?<![\n\r\t])(?=[\n\r\v])/msx;;
+    : qr/(?:(?<!\w)(?=\w)|(?<![\]\[!"%&'()*,\.\/:;?\{}\-@])(?=[\]\[!"%&'()*,\.\/:;?\{}\-@])|(?<![\n\r\t])(?=[\n\r\t]))/msx;
 
 my %styles = (
     ANSIColor    => undef,

--- a/t/ansicolor.t
+++ b/t/ansicolor.t
@@ -54,8 +54,8 @@ my $file_diff = 'This is a ' . BOLD . RED . STRIKETHROUGH . "tst;"
               . "actual diff, the results would\n"
               . 'have been output to ' . BOLD . RED . STRIKETHROUGH . "HTML"
               . RESET . BOLD . GREEN . UNDERLINE . "the terminal" . RESET . ".\n\n"
-              . 'Some string with funny ' . BOLD . RED . STRIKETHROUGH . '$'
-              . RESET . BOLD . GREEN . UNDERLINE . '@' . RESET . "\n"
+              . 'Some string with ' . BOLD . RED . STRIKETHROUGH . 'funny $'
+              . RESET . BOLD . GREEN . UNDERLINE . 'funny @' . RESET . "\n"
               . 'chars in the end' . BOLD . RED . STRIKETHROUGH . '*'
               . RESET . BOLD . GREEN . UNDERLINE . '?' . RESET . "\n";
 

--- a/t/html.t
+++ b/t/html.t
@@ -55,8 +55,8 @@ my $file_diff = qq{<div class="file">$header<span class="hunk">This is a </span>
               . qq{actual diff, the results would\n}
               . qq{have been output to </span><span class="hunk"><del>HTML</del>}
               . qq{<ins>the terminal</ins></span>}
-              . qq{<span class="hunk">.\n\nSome string with funny </span>}
-              . qq{<span class="hunk"><del>\$</del><ins>\@</ins></span>}
+              . qq{<span class="hunk">.\n\nSome string with </span>}
+              . qq{<span class="hunk"><del>funny \$</del><ins>funny \@</ins></span>}
               . qq{<span class="hunk">\nchars in the end</span>}
               . qq{<span class="hunk"><del>*</del><ins>?</ins></span>}
               . qq{<span class="hunk">\n</span></div>};

--- a/t/htmltwolines.t
+++ b/t/htmltwolines.t
@@ -56,8 +56,8 @@ my $file_diff = qq{<div class="file">$header1}
 	. qq{test. Had </span><span class="hunk"><del>it </del></span><span class="hunk">been an\n}
 	. qq{actual diff, the results would\n}
 	. qq{have been output to </span><span class="hunk"><del>HTML</del></span>}
-	. qq{<span class="hunk">.\n\nSome string with funny </span>}
-	. qq{<span class="hunk"><del>\$</del></span>}
+	. qq{<span class="hunk">.\n\nSome string with </span>}
+	. qq{<span class="hunk"><del>funny \$</del></span>}
 	. qq{<span class="hunk">\nchars in the end</span>}
 	. qq{<span class="hunk"><del>*</del></span><span class="hunk">\n</span></div>\n}
 	. qq{<div class="file">$header2}
@@ -67,8 +67,8 @@ my $file_diff = qq{<div class="file">$header1}
 	. qq{test. Had </span><span class="hunk"><ins>this </ins></span><span class="hunk">been an\n}
 	. qq{actual diff, the results would\n}
 	. qq{have been output to </span><span class="hunk"><ins>the terminal</ins></span>}
-	. qq{<span class="hunk">.\n\nSome string with funny </span>}
-	. qq{<span class="hunk"><ins>\@</ins></span>}
+	. qq{<span class="hunk">.\n\nSome string with </span>}
+	. qq{<span class="hunk"><ins>funny \@</ins></span>}
 	. qq{<span class="hunk">\nchars in the end</span>}
 	. qq{<span class="hunk"><ins>?</ins></span><span class="hunk">\n</span></div>\n};
 


### PR DESCRIPTION
Sorry for failed tests - I tested regexp for Perl v. <= 5.6, and put some extra characters in it (like $).

This characters actually is not punctuation.
Tests were updated correspondingly.
